### PR TITLE
added OPEN_LIBERTY_FQDN to env (in readme) & progress on refactor

### DIFF
--- a/DB_Engine_Networking/DiscordBot/src/main/java/API/FormData.java
+++ b/DB_Engine_Networking/DiscordBot/src/main/java/API/FormData.java
@@ -1,12 +1,21 @@
 package API;
 
+import org.apache.hc.client5.http.classic.methods.HttpDelete;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.classic.methods.HttpPut;
+import org.apache.hc.client5.http.entity.UrlEncodedFormEntity;
+import org.apache.hc.client5.http.entity.mime.HttpMultipartMode;
 import org.apache.hc.client5.http.entity.mime.MultipartEntityBuilder;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.http.HttpEntity;
+import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.hc.core5.http.NameValuePair;
+import org.apache.hc.core5.http.message.BasicNameValuePair;
+import org.apache.http.Consts;
 import org.json.JSONObject;
-
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.concurrent.CompletableFuture;
 
@@ -16,14 +25,7 @@ public class FormData {
             try {
                 CloseableHttpClient client = HttpClients.createDefault();
                 HttpPost post = new HttpPost(url);
-                MultipartEntityBuilder builder = MultipartEntityBuilder.create();
-
-                Iterator<String> keys = formDataJson.keys();
-                while(keys.hasNext()) {
-                    String key = keys.next();
-                    builder.addTextBody(key, formDataJson.getString(key));
-                }
-                post.setEntity(builder.build());
+                post.setEntity(buildMultipartJson(formDataJson));
                 return client.execute(post);
             }
             catch (Exception e) {
@@ -31,5 +33,58 @@ public class FormData {
                 return null;
             }
         });
+    }
+
+    public CompletableFuture<CloseableHttpResponse> delete(JSONObject formDataJson, String url) {
+        return CompletableFuture.supplyAsync(() -> {
+            try {
+                CloseableHttpClient client = HttpClients.createDefault();
+                HttpDelete delete = new HttpDelete(url);
+                delete.setEntity(buildMultipartJson(formDataJson));
+                return client.execute(delete);
+            }
+            catch (Exception e) {
+                e.printStackTrace();
+                return null;
+            }
+        });
+    }
+
+    public CompletableFuture<CloseableHttpResponse> put(JSONObject formDataJson, String url) {
+        return CompletableFuture.supplyAsync(() -> {
+            try {
+                CloseableHttpClient client = HttpClients.createDefault();
+                HttpPut put = new HttpPut(url);
+                put.setHeader(HttpHeaders.CONTENT_TYPE, "application/x-www-form-urlencoded");
+                put.setEntity(buildUrlMultipartJson(formDataJson));
+                return client.execute(put);
+            }
+            catch (Exception e) {
+                e.printStackTrace();
+                return null;
+            }
+        });
+    }
+
+    private HttpEntity buildMultipartJson(JSONObject body) {
+        MultipartEntityBuilder builder = MultipartEntityBuilder.create();
+        builder.setMode(HttpMultipartMode.EXTENDED);
+
+        Iterator<String> keys = body.keys();
+        while(keys.hasNext()) {
+            String key = keys.next();
+            builder.addTextBody(key, body.getString(key));
+        }
+        return builder.build();
+    }
+
+    private HttpEntity buildUrlMultipartJson(JSONObject body) {
+        ArrayList<NameValuePair> formData = new ArrayList<>();
+        Iterator<String> keys = body.keys();
+        while(keys.hasNext()) {
+            String key = keys.next();
+            formData.add(new BasicNameValuePair(key, body.getString(key)));
+        }
+        return new UrlEncodedFormEntity(formData, Consts.UTF_8);
     }
 }

--- a/DB_Engine_Networking/DiscordBot/src/main/java/DiscordAPI/HandleReactions.java
+++ b/DB_Engine_Networking/DiscordBot/src/main/java/DiscordAPI/HandleReactions.java
@@ -3,6 +3,7 @@ package DiscordAPI;
 import API.JavaFormData;
 import Admin.Database;
 import Admin.User;
+import io.github.cdimascio.dotenv.Dotenv;
 import org.javacord.api.DiscordApi;
 import org.javacord.api.entity.message.Reaction;
 import org.json.JSONArray;
@@ -79,7 +80,7 @@ public class HandleReactions {
             return CompletableFuture.supplyAsync(() -> {
                 JavaFormData request = null;
                 try {
-                    request = new JavaFormData(new URL("http://localhost:9080/api/bot/reactions"));
+                    request = new JavaFormData(new URL(Dotenv.load().get("OPEN_LIBERTY_FQDN") + "/api/bot/reactions"));
                 } catch (IOException e) {
                     throw new RuntimeException(e);
                 }

--- a/DB_Engine_Networking/DiscordBot/src/main/java/DiscordAPI/HandleTextChannels.java
+++ b/DB_Engine_Networking/DiscordBot/src/main/java/DiscordAPI/HandleTextChannels.java
@@ -3,14 +3,12 @@ package DiscordAPI;
 import API.FormData;
 import Admin.Database;
 import Admin.User;
+import io.github.cdimascio.dotenv.Dotenv;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
-import org.apache.hc.core5.http.HttpResponse;
 import org.javacord.api.DiscordApi;
 import org.javacord.api.entity.channel.ServerTextChannel;
 import org.javacord.api.entity.channel.TextChannel;
 import org.json.JSONObject;
-
-import java.sql.SQLException;
 import java.util.concurrent.CompletableFuture;
 
 public class HandleTextChannels {
@@ -33,7 +31,7 @@ public class HandleTextChannels {
         channelJson.put("server_id", "" + serverId);
         channelJson.put("channel_id", "" + channelId);
         channelJson.put("channel_name", "" + channelName);
-        return request.post(channelJson, "http://localhost:9080/api/bot/channel");
+        return request.post(channelJson, Dotenv.load().get("OPEN_LIBERTY_FQDN") + "/api/bot/channel");
     }
 
     private void listenForTextChannelNicknameChange() {

--- a/DB_Engine_Networking/DiscordBot/src/main/java/DiscordAPI/RunBot.java
+++ b/DB_Engine_Networking/DiscordBot/src/main/java/DiscordAPI/RunBot.java
@@ -9,6 +9,8 @@ import org.javacord.api.DiscordApiBuilder;
 import org.javacord.api.entity.intent.Intent;
 import org.javacord.api.entity.server.Server;
 
+import java.util.Objects;
+
 public class RunBot {
 
     /**
@@ -19,6 +21,11 @@ public class RunBot {
     public static void main(String[] args) throws Exception {
         // use .env file (root directory by default)
         Dotenv envFile = Dotenv.load();
+
+        if(Dotenv.load().get("OPEN_LIBERTY_FQDN") == null || Objects.equals(Dotenv.load().get("OPEN_LIBERTY_FQDN"), "")) {
+            System.out.println("ERROR:\nMISSING ENV VARIABLE:\nOPEN_LIBERTY_FQDN");
+            return;
+        }
 
         DiscordApi discordApi = connectToDiscordApi(envFile);
 

--- a/DB_Engine_Networking/OpenLiberty/src/main/java/software/design/rest/Resources/BotResource.java
+++ b/DB_Engine_Networking/OpenLiberty/src/main/java/software/design/rest/Resources/BotResource.java
@@ -30,7 +30,7 @@ public class BotResource {
     @Path("channel")
     @DELETE
     public void DeleteChannel(@FormParam("server_id") String server_id, @FormParam("channel_id") String channel_id) throws SQLException {
-        Database db = null;
+        Database db;
         try{
             db = RestApplication.getRestDatabase(Long.parseLong(server_id), "MYSQL_URL", "MYSQL_BOT_USER", "MYSQL_BOT_USER_PASSWORD");
         }catch (SQLException e) {
@@ -76,7 +76,7 @@ public class BotResource {
     @Path("channel")
     @POST
     public Response postChannel(@FormParam("server_id") String server_id,@FormParam("channel_id") String channel_id, @FormParam("channel_name") String channel_name){
-        Database db = null;
+        Database db;
         try {
             db = RestApplication.getRestDatabase(Long.parseLong(server_id), "MYSQL_URL", "MYSQL_BOT_USER", "MYSQL_BOT_USER_PASSWORD");
             db.create.channel(Long.parseLong(channel_id),channel_name);
@@ -102,7 +102,7 @@ public class BotResource {
     @Path("author")
     @POST
     public Response postAuthor(@FormParam("server_id") String server_id, @FormParam("author_id") String author_id, @FormParam("author_name") String author_name,@FormParam("avatar_hash") String avatar_hash){
-        Database db = null;
+        Database db;
         try{
             db = RestApplication.getRestDatabase(Long.parseLong(server_id), "MYSQL_URL", "MYSQL_BOT_USER", "MYSQL_BOT_USER_PASSWORD");
             db.create.author(Long.parseLong(author_id), author_name,avatar_hash);
@@ -124,7 +124,8 @@ public class BotResource {
     @Path("author")
     @PUT
     public Response updateAuthor(@FormParam("server_id") String server_id, @FormParam("author_id") String author_id, @FormParam("author_name") String author_name){
-        Database db = null;
+        Database db;
+        System.out.println(server_id); System.out.println(author_id); System.out.println(author_name);
         try{
             db = RestApplication.getRestDatabase(Long.parseLong(server_id), "MYSQL_URL", "MYSQL_BOT_USER", "MYSQL_BOT_USER_PASSWORD");
             db.update.authorNickname(Long.parseLong(author_id), author_name);
@@ -149,7 +150,7 @@ public class BotResource {
     @Path("messages")
     @POST
     public Response createMsg(@FormParam("server_id") String server_id, @FormParam("message_id") String message_id,@FormParam("author_id") String author_id, @FormParam("channel_id") String channel_id, @FormParam("content") String content) {
-        Database db = null;
+        Database db;
         try{
             db = RestApplication.getRestDatabase(Long.parseLong(server_id), "MYSQL_URL", "MYSQL_BOT_USER", "MYSQL_BOT_USER_PASSWORD");
             db.create.message(Long.parseLong(message_id),Long.parseLong(author_id),Long.parseLong(channel_id),content);
@@ -172,7 +173,7 @@ public class BotResource {
     @Path("messages")
     @PUT
     public Response updateMsg(@FormParam("server_id") String server_id, @FormParam("message_id") String message_id, @FormParam("content") String content, @FormParam("time") String time) {
-        Database db = null;
+        Database db;
         try{
             db = RestApplication.getRestDatabase(Long.parseLong(server_id), "MYSQL_URL", "MYSQL_BOT_USER", "MYSQL_BOT_USER_PASSWORD");
             db.update.message(Long.parseLong(message_id),content,Long.parseLong(time));
@@ -194,7 +195,7 @@ public class BotResource {
     @Path("messages")
     @DELETE
     public Response deleteMsg(@FormParam("server_id") String server_id, @FormParam("message_id") String message_id) throws SQLException {
-        Database db = null;
+        Database db;
         try{
             db = RestApplication.getRestDatabase(Long.parseLong(server_id), "MYSQL_URL", "MYSQL_BOT_USER", "MYSQL_BOT_USER_PASSWORD");
             db.delete.message(Long.parseLong(message_id));

--- a/DB_Engine_Networking/README.md
+++ b/DB_Engine_Networking/README.md
@@ -27,6 +27,8 @@ https://localhost:9443/ibm/api/social-login/redirect/discordLogin
 ```.env
 DISCORD_BOT_TOKEN=""
 
+OPEN_LIBERTY_FQDN="http://localhost:9080"
+
 MYSQL_URL="jdbc:mysql://localhost:3306/"
 
 MYSQL_INITIALIZATION_USER="OZ_init"
@@ -40,6 +42,7 @@ MYSQL_BOT_USER_PASSWORD="password"
 ```
 Note: *It is recommended to surround the values with quotes to prevent some machines causing issues with special characters.*
 - Set `DISCORD_BOT_TOKEN` equal to the token of your discord bot.
+- Set `OPEN_LIBERTY_FQDN` equal to the url of your OpenLiberty server + port (if applicable)
 - Set `MYSQL_URL` equal to the URL of your MySQL server. localhost being the IP address, then 3306 being the port (default).
 - Set `MYSQL_INITIALIZATION_USER` equal to the username of the MySQL user you created earlier.
 - Set `MYSQL_INITIALIZATION_USER_PASSWORD` equal to the password of the MySQL user you created earlier.


### PR DESCRIPTION
- BREAKING: DiscordBot will not start without OPEN_LIBERTY_FQDN in .env. look at readme for example.
- Bot now uses the OPEN_LIBERTY_FQDN from .env to get the base request url
- HandleAuthors refactor is completed
- Small changes to other Handle classes
- Added put & delete methods to FormData class