### PR TITLE
added preflight responses for all user requests (api/v10 & api/discord)

### DIFF
--- a/DB_Engine_Networking/OpenLibertyAPI/src/main/java/software/design/rest/Resources/DiscordResource.java
+++ b/DB_Engine_Networking/OpenLibertyAPI/src/main/java/software/design/rest/Resources/DiscordResource.java
@@ -13,6 +13,11 @@ import java.util.Iterator;
 
 @Path("discord")
 public class DiscordResource {
+    @Path("Nickname")
+    @OPTIONS
+    public Response preflightNickname() {
+        return RestApplication.defaultPreflightResponse();
+    }
     /**
      * Nickname response.
      *
@@ -42,6 +47,12 @@ public class DiscordResource {
             return Response.status(Response.Status.NOT_FOUND).header("Access-Control-Allow-Origin", "*").build();
         }
     }
+
+    @Path("Msg")
+    @OPTIONS
+    public Response preflightMsg() {
+        return RestApplication.defaultPreflightResponse();
+    }
     /**
      * Returns the Messages from the server. This those not work at the moment need to talk to DB about it.Maybe add a Server Id in the url always
      *
@@ -68,6 +79,12 @@ public class DiscordResource {
         }else {
             return Response.status(Response.Status.NOT_FOUND).header("Access-Control-Allow-Origin", "*").build();
         }
+    }
+
+    @Path("MsgByAuthor")
+    @OPTIONS
+    public Response preflightMsgByAuthor() {
+        return RestApplication.defaultPreflightResponse();
     }
     /**
      * Return the Messages by author response using the Server_id, and the Discoed_id of the author.
@@ -99,6 +116,11 @@ public class DiscordResource {
         }
     }
 
+    @Path("msgs-in-channel")
+    @OPTIONS
+    public Response preflightMsgsInChannel() {
+        return RestApplication.defaultPreflightResponse();
+    }
     @Path("msgs-in-channel")
     @POST
     @Produces

--- a/DB_Engine_Networking/OpenLibertyAPI/src/main/java/software/design/rest/Resources/DiscordResource.java
+++ b/DB_Engine_Networking/OpenLibertyAPI/src/main/java/software/design/rest/Resources/DiscordResource.java
@@ -13,17 +13,6 @@ import java.util.Iterator;
 
 @Path("discord")
 public class DiscordResource {
-    @Path("demoPath")
-    @GET
-    @Produces(MediaType.APPLICATION_JSON)
-    public Response jwtProtectedPath(@Context HttpHeaders headers) {
-        if(!RestApplication.isAcceptedJwt(headers)) {
-            return Response.status(Response.Status.UNAUTHORIZED).build();
-        }
-        // else continue doing stuff
-        return Response.status(Response.Status.ACCEPTED).build();
-    }
-
     /**
      * Nickname response.
      *

--- a/DB_Engine_Networking/OpenLibertyAPI/src/main/java/software/design/rest/Resources/VersionTen.java
+++ b/DB_Engine_Networking/OpenLibertyAPI/src/main/java/software/design/rest/Resources/VersionTen.java
@@ -24,6 +24,11 @@ import java.io.IOException;
 
 @Path("v10")
 public class VersionTen {
+    @Path("@me/claims")
+    @OPTIONS
+    public Response preflightMeClaims() {
+        return RestApplication.defaultPreflightResponse();
+    }
     /**
      * Get Claims
      */
@@ -43,6 +48,11 @@ public class VersionTen {
         }
     }
 
+    @Path("@me/guilds")
+    @OPTIONS
+    public Response preflightMeGuilds() {
+        return RestApplication.defaultPreflightResponse();
+    }
     /**
      * Get all guilds you're in, which the bot is also in
      */
@@ -74,6 +84,11 @@ public class VersionTen {
         return Response.status(Response.Status.ACCEPTED).header("Access-Control-Allow-Origin", "*").entity(guilds.toString()).build();
     }
 
+    @Path("channels")
+    @OPTIONS
+    public Response preflightPostChannels() {
+        return RestApplication.defaultPreflightResponse();
+    }
     /**
      *
      */
@@ -89,6 +104,11 @@ public class VersionTen {
         return postDiscordApi("https://discord.com/api/v10/users/@me/channels", body, true, headers);
     }
 
+    @Path("guilds/{guildId}/channels")
+    @OPTIONS
+    public Response preflightPostGuildChannels() {
+        return RestApplication.defaultPreflightResponse();
+    }
     /**
      *
      */
@@ -114,6 +134,11 @@ public class VersionTen {
         }
     }
 
+    @Path("guilds/{guildId}/channels")
+    @OPTIONS
+    public Response preflightGetChannels() {
+        return RestApplication.defaultPreflightResponse();
+    }
     /**
      * Get all the channels in a guild
      */

--- a/DB_Engine_Networking/OpenLibertyAPI/src/main/java/software/design/rest/Resources/VersionTen.java
+++ b/DB_Engine_Networking/OpenLibertyAPI/src/main/java/software/design/rest/Resources/VersionTen.java
@@ -134,11 +134,6 @@ public class VersionTen {
         }
     }
 
-    @Path("guilds/{guildId}/channels")
-    @OPTIONS
-    public Response preflightGetChannels() {
-        return RestApplication.defaultPreflightResponse();
-    }
     /**
      * Get all the channels in a guild
      */

--- a/DB_Engine_Networking/OpenLibertyAPI/src/main/java/software/design/rest/RestApplication.java
+++ b/DB_Engine_Networking/OpenLibertyAPI/src/main/java/software/design/rest/RestApplication.java
@@ -41,6 +41,10 @@ The RestApplication class adds Resources to the project so that things are aware
         return singletons;
     }
 
+    public static Response defaultPreflightResponse() {
+        return Response.status(Response.Status.OK).header("Access-Control-Allow-Origin", "*").header("Access-Control-Allow-Headers", "Authorization").build();
+    }
+
     public static Database getRestDatabase(long id, String envURl, String envUser, String envPassword ) throws SQLException {
         Dotenv dotenv = Dotenv.configure().directory("../../../../../../").load();
         return new Database(id, dotenv.get(envURl), dotenv.get(envUser), dotenv.get(envPassword));


### PR DESCRIPTION
- api/discord/demoPath was removed
- Created defaultPreflightResponse() in RestApplication class. *This allows all origins. We may want to consider changing the allowed origins to a config file.
- Added OPTIONS in addition to all existing REST Routes. Example: POST api/discord/msgs-in-channel also has a OPTIONS api/discord/msgs-in-channel to comply with CORS preflight policies.