### PR TITLE
Changed + " UTC" in Messages.js to + "+00:00"

### DIFF
--- a/DB_Engine_Networking/OpenLibertyFrontend/src/main/frontend/src/Message.js
+++ b/DB_Engine_Networking/OpenLibertyFrontend/src/main/frontend/src/Message.js
@@ -10,7 +10,7 @@ function Message({message, filters, dictionary, shareMenu}) {
     const reactions = message.reactions;
     function timeDisplay() {
         const currentTime = Date.now();
-        const updatedTime = new Date(message.updated_at + " UTC");
+        const updatedTime = new Date(message.updated_at + "+00:00");
         var difference = currentTime - updatedTime;
         difference = Math.floor(difference / 1000);
         if(difference < 60) return (


### PR DESCRIPTION
" UTC" is not supported by all browsers. "+00:00" is equivalent and supported by all modern browsers.